### PR TITLE
Readme and path separators

### DIFF
--- a/Grillbot/Properties/launchSettings.json
+++ b/Grillbot/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     },
     "Grillbot": {
       "commandName": "Project",
-      "workingDirectory": "bin\\debug\\netcoreapp2.2",
+      "workingDirectory": "bin/Debug/netcoreapp2.2",
       "launchUrl": "api/values",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - Config parts
   - AllowedHosts (string): Semicollon delimited list of allowed hostnames without port numbers.
   - CommandPrefix (string): Message content, that must contain to invoke command.
-  - **Database** (string): Connection string to database. 
+  - **Database** (string): Connection string to database. **If you don't want to setup Db locally ask Misha for remote connection string**
   - Discord: Bot configuration
     - Activity (string): Activity message
     - **Token** (string): Bot login token **You will need to create your own Discord Application to get a Token for local development**

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@
 - MathParser.org-mXParser
 
 ## GrillBot config
+**Keys in bold must be setup to develop GrillBot locally**
 - Format: **JSON**
 - Config parts
   - AllowedHosts (string): Semicollon delimited list of allowed hostnames without port numbers.
   - CommandPrefix (string): Message content, that must contain to invoke command.
-  - Database (string): Connection string to database.
+  - **Database** (string): Connection string to database. 
   - Discord: Bot configuration
     - Activity (string): Activity message
-    - Token (string): Bot login token
+    - **Token** (string): Bot login token **You will need to create your own Discord Application to get a Token for local development**
     - UserJoinedMessage (string): Message, that will be sent, when user joined to guild.
     - Administrators (string[]): List of bot administrators. Can use bot independently of roles.
     - LoggerRoomID (string): ID of channel to send logging data.


### PR DESCRIPTION
#24  #25 

Highlighted important config parts in Readme and change path separators to Unix one, because they should work on Windows aswell (Didn't test it)