### PR TITLE
Implemented emoji support for emote chain

### DIFF
--- a/Grillbot/Grillbot.csproj
+++ b/Grillbot/Grillbot.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
+    <PackageReference Include="UnicodeEmoji.net" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Grillbot/Services/EmoteChain.cs
+++ b/Grillbot/Services/EmoteChain.cs
@@ -101,15 +101,15 @@ namespace Grillbot.Services
                .Where(o => o.Type == TagType.Emoji && context.Guild.Emotes.Any(x => x.Id == o.Key))
                .ToList();
 
-			var isUTFEmoji = NeoSmart.Unicode.Emoji.IsEmoji(context.Message.Content);
+            var isUTFEmoji = NeoSmart.Unicode.Emoji.IsEmoji(context.Message.Content);
 
             if (emotes.Count == 0 && !isUTFEmoji) return false;
 
-			if (!IsValidWithWithFirstInChannel(context)) return false;
+            if (!IsValidWithWithFirstInChannel(context)) return false;
 
             var emoteTemplate = string.Join(" ", emotes.Select(o => o.Value.ToString()));
-			return emoteTemplate == context.Message.Content || isUTFEmoji;
-		}
+            return emoteTemplate == context.Message.Content || isUTFEmoji;
+        }
 
         public void ConfigChanged(Configuration newConfig)
         {

--- a/Grillbot/Services/EmoteChain.cs
+++ b/Grillbot/Services/EmoteChain.cs
@@ -101,11 +101,15 @@ namespace Grillbot.Services
                .Where(o => o.Type == TagType.Emoji && context.Guild.Emotes.Any(x => x.Id == o.Key))
                .ToList();
 
-            if (emotes.Count == 0) return false;
+			var isUTFEmoji = NeoSmart.Unicode.Emoji.IsEmoji(context.Message.Content);
+
+            if (emotes.Count == 0 && !isUTFEmoji) return false;
+
+			if (!IsValidWithWithFirstInChannel(context)) return false;
 
             var emoteTemplate = string.Join(" ", emotes.Select(o => o.Value.ToString()));
-            return emoteTemplate == context.Message.Content && IsValidWithWithFirstInChannel(context);
-        }
+			return emoteTemplate == context.Message.Content || isUTFEmoji;
+		}
 
         public void ConfigChanged(Configuration newConfig)
         {


### PR DESCRIPTION
This is a fix for issue #62.

I have added a NuGet package [UnicodeEmoji.net](https://www.nuget.org/packages/UnicodeEmoji.net) which includes method `Emoji.IsEmoji(string message, int maxSymbolCount)` that checks if the provided string only contains emoji characters.

This should support all current emoji up to Unicode 12, but when I tested it, some v12 emoji haven't trigger the emote chain. This could be Discord limitation because the Discord client acts weird with some of the new emoji.